### PR TITLE
Add a --no-commit to not display the commit list in the description o…

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,8 @@ Prepares a merge request description, with link to Jira ticket and current branc
   Disable terminal colors.
 * `--no-links`  
   Disable terminal hyperlinks and show merge request URL in `mr status` and `mr menu status`.
+* `--no-commit`  
+  Do not display the list of commit in the Merge Request description.
 * `-y`, `--yes`  
   Bypass confirmation prompts (always answer "yes").
 * `-v`, `--verbose`  

--- a/README.md
+++ b/README.md
@@ -151,7 +151,7 @@ Completion functions for Bash and Zsh are available:
 * **Zsh**   
   Add the `completion` directory to your `fpath` (in your `.zshrc`, before any call to `compinit` or `oh-my-zsh.sh`)
   ```zsh
-  fpath=("~/path/to/git-mr/completion" $fpath)
+  fpath=("/path/to/git-mr/completion" $fpath)
   ```
   You may have to force a rebuild of `zcompdump` by running:
   ```zsh

--- a/README.md
+++ b/README.md
@@ -74,8 +74,8 @@ Prepares a merge request description, with link to Jira ticket and current branc
   Disable terminal colors.
 * `--no-links`  
   Disable terminal hyperlinks and show merge request URL in `mr status` and `mr menu status`.
-* `--no-commit`  
-  Do not display the list of commit in the Merge Request description.
+* `--no-commits`  
+  Do not display the list of commits in the merge request description.
 * `-y`, `--yes`  
   Bypass confirmation prompts (always answer "yes").
 * `-v`, `--verbose`  

--- a/completion/_git-mr
+++ b/completion/_git-mr
@@ -82,6 +82,7 @@ _git-mr() {
     case $mr_action in default|open|update) opts+=(
         '(-t --target)'{-t,--target}'[force target branch]:merge request target branch:->target_branch'
         '(-e --extended)'{-e,--extended}'[use full commit messages in description]'
+        '(--no-commits)'--no-commits'[omit commit list from description]'
     );; esac
     case $mr_action in default|open|status|menu-status) opts+=(
         '(--no-color)'--no-color'[disable terminal colors]'

--- a/git-mr
+++ b/git-mr
@@ -1065,6 +1065,7 @@ mr_print_description() {
         cat <<EOF
 $(markdown_title "$title")
 
+
 ## Commits
 
 ${commit_list}

--- a/git-mr
+++ b/git-mr
@@ -1050,7 +1050,7 @@ mr_description() {
 
     local title; title=$(mr_title "$source_branch" "$issue_code")
 
-    if [[ "${GIT_MR_NO_COMMIT}" == "1" ]]; then
+    if [[ "${GIT_MR_NO_COMMITS}" == "1" ]]; then
         mr_print_description "$title"
     else 
         mr_print_description "$title" "$(mr_commit_list "$source_branch" "$target_branch")"
@@ -2702,7 +2702,7 @@ while [[ $# -gt 0 ]]; do
 
         -y|--yes)     GIT_MR_YES=1 ;;
         -v|--verbose) GIT_MR_VERBOSE=1 ;;
-        --no-commit)  GIT_MR_NO_COMMIT=1 ;;
+        --no-commits) GIT_MR_NO_COMMITS=1 ;;
 
         # mr update
         -n|--new-section) GIT_MR_UPDATE_NEW_SECTION=1

--- a/git-mr
+++ b/git-mr
@@ -1050,22 +1050,32 @@ mr_description() {
 
     local title; title=$(mr_title "$source_branch" "$issue_code")
 
-    mr_print_description "$title" "$(mr_commit_list "$source_branch" "$target_branch")"
+    if [[ "${GIT_MR_NO_COMMIT}" == "1" ]]; then
+        mr_print_description "$title"
+    else 
+        mr_print_description "$title" "$(mr_commit_list "$source_branch" "$target_branch")"
+    fi
+    
 }
 
 mr_print_description() {
     local title=$1
-    local commit_list=$2
-
-    cat <<EOF
+    if [[ -n $2 ]]; then
+        local commit_list=$2
+        cat <<EOF
 $(markdown_title "$title")
-
 
 ## Commits
 
 ${commit_list}
 
 EOF
+    else
+        cat <<EOF
+$(markdown_title "$title")
+
+EOF
+    fi
 }
 
 mr_status_block() {
@@ -2692,6 +2702,7 @@ while [[ $# -gt 0 ]]; do
 
         -y|--yes)     GIT_MR_YES=1 ;;
         -v|--verbose) GIT_MR_VERBOSE=1 ;;
+        --no-commit)  GIT_MR_NO_COMMIT=1 ;;
 
         # mr update
         -n|--new-section) GIT_MR_UPDATE_NEW_SECTION=1

--- a/git-mr-completion.bash
+++ b/git-mr-completion.bash
@@ -85,6 +85,7 @@ _git_mr() {
         case $mr_action in default | open | update)
             __gitcomp_nl_append '-t'; __gitcomp_nl_append '--target'
             __gitcomp_nl_append '-e'; __gitcomp_nl_append '--extended'
+            __gitcomp_nl_append '--no-commits'
         ;; esac
         case $mr_action in default | open | status | menu-status)
             __gitcomp_nl_append '--no-color'

--- a/test/git-mr.bats
+++ b/test/git-mr.bats
@@ -11,6 +11,7 @@ setup_file() {
 
     export GIT_MR_NO_COLORS=1
     export GIT_MR_NO_TERMINAL_LINK=1
+    export GIT_MR_NO_COMMITS=
     export GIT_MR_EXTENDED=
 
     export JIRA_CODE_PATTERN="[A-Z]{2,3}-[0-9]+"
@@ -845,6 +846,17 @@ full_sha() {
     c2sha=$(short_sha "Feature test - 2")
     c3sha=$(short_sha "Feature test - 3")
 
+    GIT_MR_NO_COMMITS=1
+    GIT_MR_EXTENDED=
+    run mr_description
+
+    assert_output "$(cat <<- EOF
+		# [AB-123 This is an issue](https://mycompany.example.net/browse/AB-123)
+
+		EOF
+    )"
+
+    GIT_MR_NO_COMMITS=
     GIT_MR_EXTENDED=
     run mr_description
 


### PR DESCRIPTION
# Ajout d'une option `--no-commit` 

Je souhaite ajouter la possibilité de ne pas lister les commits dans la description de la MR pour 2 raisons.

- Une branche sur trois va voir ses commits amend post création de la MR sans que le dev ne pense à mettre à jour les hash dans la description, résultat en CR il arrive qu'on regarde des commits qui ne sont plus les bons.
- Si le dev juge qu'une information importante sur un commit doit être ajouté, je trouve que c'est une bonne pratique de le faire dans le descriptif du commit plutôt que de la MR car c'est plus pérenne dans le temps.