### PR TITLE
Allow skipping prepare-commit-msg hook

### DIFF
--- a/hooks/prepare-commit-msg
+++ b/hooks/prepare-commit-msg
@@ -7,6 +7,9 @@
 # Allow skipping
 case ${SKIP:-} in *prepare-commit-msg*) exit 0 ;; esac
 
+# Don't alter fixup messages
+grep -q "^fixup! " "$1" && exit 0
+
 JIRA_CODE_PATTERN=${JIRA_CODE_PATTERN:-$(git config --get mr.jira-code-pattern)}
 if [ -z "$JIRA_CODE_PATTERN" ]; then
     echo "JIRA_CODE_PATTERN not set - unable to guess issue code" >&2
@@ -20,10 +23,6 @@ issue_code=$(echo "${current_branch}" | grep -Eo "$JIRA_CODE_PATTERN" | tail -n1
 current_msg=$(cat "$1")
 msg_code=$(echo "${current_msg}" | grep -iEo "$JIRA_CODE_PATTERN" | tail -n1)
 [ -z "$msg_code" ] || exit 0 # existing issue code in message
-
-if case "$current_msg" in "fixup! "*) ;; *) false;; esac; then
-    exit 0 # don't alter fixup messages
-fi
 
 echo "Prefixing message with issue code: $issue_code" >&2
 sed -i.bak -e "1s/^/$issue_code /" "$1"

--- a/hooks/prepare-commit-msg
+++ b/hooks/prepare-commit-msg
@@ -16,13 +16,12 @@ if [ -z "$JIRA_CODE_PATTERN" ]; then
     exit 0
 fi
 
+# Exit if code already present in message header
+head -n 1 "$1" | grep -Eiq "$JIRA_CODE_PATTERN" && exit 0
+
 current_branch=$(git rev-parse --abbrev-ref HEAD)
 issue_code=$(echo "${current_branch}" | grep -Eo "$JIRA_CODE_PATTERN" | tail -n1)
 [ -n "$issue_code" ] || exit 0 # No issue code detected
-
-current_msg=$(cat "$1")
-msg_code=$(echo "${current_msg}" | grep -iEo "$JIRA_CODE_PATTERN" | tail -n1)
-[ -z "$msg_code" ] || exit 0 # existing issue code in message
 
 echo "Prefixing message with issue code: $issue_code" >&2
 sed -i.bak -e "1s/^/$issue_code /" "$1"

--- a/hooks/prepare-commit-msg
+++ b/hooks/prepare-commit-msg
@@ -4,6 +4,9 @@
 # When on a branch referring to a Jira issue,
 # ensure commit messages start with the issue reference
 
+# Allow skipping
+case ${SKIP:-} in *prepare-commit-msg*) exit 0 ;; esac
+
 JIRA_CODE_PATTERN=${JIRA_CODE_PATTERN:-$(git config --get mr.jira-code-pattern)}
 if [ -z "$JIRA_CODE_PATTERN" ]; then
     echo "JIRA_CODE_PATTERN not set - unable to guess issue code" >&2

--- a/test/git-mr.bats
+++ b/test/git-mr.bats
@@ -2719,8 +2719,12 @@ n'
     refute_line "Prefixing message with issue code: AB-123"
     assert_line "[feature/AB-123-test-feature $(git rev-parse --short HEAD)] fixup! Test message 1"
 
+    run git commit --allow-empty -m "XY-456 Test message 3"
+    refute_line "Prefixing message with issue code: AB-123"
+    assert_line "[feature/AB-123-test-feature $(git rev-parse --short HEAD)] XY-456 Test message 3"
+
     # standard .git directory - teardown
-    git reset --hard HEAD~3
+    git reset --hard HEAD~4
     rm -f .git/hooks/prepare-commit-msg
 
     # submodule

--- a/test/git-mr.bats
+++ b/test/git-mr.bats
@@ -2715,8 +2715,12 @@ n'
     assert_line "Prefixing message with issue code: AB-123"
     assert_line "[feature/AB-123-test-feature $(git rev-parse --short HEAD)] AB-123 Test message 2"
 
+    run git commit --allow-empty --fixup HEAD~1
+    refute_line "Prefixing message with issue code: AB-123"
+    assert_line "[feature/AB-123-test-feature $(git rev-parse --short HEAD)] fixup! Test message 1"
+
     # standard .git directory - teardown
-    git reset --hard HEAD~2
+    git reset --hard HEAD~3
     rm -f .git/hooks/prepare-commit-msg
 
     # submodule


### PR DESCRIPTION
Note: `prepare-commit-msg` hook can not be bypassed with the `--no-verify` option.

See https://git-scm.com/docs/githooks#_prepare_commit_msg

-> use `SKIP` env var